### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/Geo/Region.pm
+++ b/lib/Geo/Region.pm
@@ -1,4 +1,4 @@
-class Geo::Region;
+unit class Geo::Region;
 
 has @!includes;
 has @!excludes;

--- a/lib/Geo/Region/Enum.pm
+++ b/lib/Geo/Region/Enum.pm
@@ -1,4 +1,4 @@
-module Geo::Region::Enum;
+unit module Geo::Region::Enum;
 
 enum Region is export (
     Africa            => '002',


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.