### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.*",
     "name"        : "Geo::Region",
+    "license"     : "GPL-1.0+ OR Artistic-1.0-Perl",
     "version"     : "*",
     "author"      : "Nick Patch",
     "description" : "Geographical regions and groupings using UN M.49 and CLDR data",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license